### PR TITLE
feat: adicionar base de identidade com autenticação JWT e verificação de saúde 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 roadmap-aprendizado.md
+preparação.md
+
+
+target

--- a/README.md
+++ b/README.md
@@ -1,88 +1,202 @@
 # Mini-ERP de Compras, Estoque e Recebimento
 
-![Status](https://img.shields.io/badge/status-planning-334155?style=flat-square)
-![Java](https://img.shields.io/badge/Java-backend-334155?style=flat-square&logo=openjdk&logoColor=white)
-![Spring Boot](https://img.shields.io/badge/Spring_Boot-platform-334155?style=flat-square&logo=springboot&logoColor=white)
-![PostgreSQL](https://img.shields.io/badge/PostgreSQL-data-334155?style=flat-square&logo=postgresql&logoColor=white)
-![Docker](https://img.shields.io/badge/Docker-containers-334155?style=flat-square&logo=docker&logoColor=white)
-![OVHcloud](https://img.shields.io/badge/OVHcloud-cloud-334155?style=flat-square)
-![Terraform](https://img.shields.io/badge/Terraform-IaC-334155?style=flat-square&logo=terraform&logoColor=white)
-![Ansible](https://img.shields.io/badge/Ansible-automation-334155?style=flat-square&logo=ansible&logoColor=white)
-![GitHub Actions](https://img.shields.io/badge/GitHub_Actions-CI%2FCD-334155?style=flat-square&logo=githubactions&logoColor=white)
-![Kubernetes](https://img.shields.io/badge/Kubernetes-roadmap-334155?style=flat-square&logo=kubernetes&logoColor=white)
-![Make](https://img.shields.io/badge/Make-workflows-334155?style=flat-square&logo=gnu&logoColor=white)
-![Accessibility](https://img.shields.io/badge/Accessibility-first-334155?style=flat-square)
+![Status](https://img.shields.io/badge/status-foundation_in_progress-334155?style=flat-square)
+![Java](https://img.shields.io/badge/Java-17-334155?style=flat-square&logo=openjdk&logoColor=white)
+![Spring Boot](https://img.shields.io/badge/Spring_Boot-3.3-334155?style=flat-square&logo=springboot&logoColor=white)
+![Spring Security](https://img.shields.io/badge/Spring_Security-JWT-334155?style=flat-square&logo=springsecurity&logoColor=white)
+![Flyway](https://img.shields.io/badge/Flyway-migrations-334155?style=flat-square&logo=flyway&logoColor=white)
+![H2](https://img.shields.io/badge/H2-dev_database-334155?style=flat-square)
+![Actuator](https://img.shields.io/badge/Actuator-healthcheck-334155?style=flat-square)
+![Docker](https://img.shields.io/badge/Docker-roadmap-334155?style=flat-square&logo=docker&logoColor=white)
+![Terraform](https://img.shields.io/badge/Terraform-roadmap-334155?style=flat-square&logo=terraform&logoColor=white)
+![Ansible](https://img.shields.io/badge/Ansible-roadmap-334155?style=flat-square&logo=ansible&logoColor=white)
+![OVHcloud](https://img.shields.io/badge/OVHcloud-target-334155?style=flat-square)
+![GitHub Actions](https://img.shields.io/badge/GitHub_Actions-roadmap-334155?style=flat-square&logo=githubactions&logoColor=white)
 
-Projeto de estudo e portfolio orientado a engenharia de software e DevOps, com foco na construcao de um Mini-ERP web para o fluxo de compras, recebimento e controle de estoque.
+Projeto de estudo e portfólio orientado a engenharia de software e DevOps, com foco na construção de um Mini-ERP web para o fluxo de compras, recebimento e controle de estoque.
 
-O objetivo nao e apenas entregar funcionalidade de negocio, mas demonstrar um processo completo de engenharia: documentacao antes da implementacao, modelagem de dominio, API REST em Java com Spring Boot, frontend acessivel, infraestrutura como codigo, automacao, testes, CI/CD e operacao em nuvem.
+O objetivo do repositório é demonstrar a evolução de um sistema corporativo pequeno com Java como linguagem principal, combinando documentação, modelagem, backend, segurança, observabilidade, automação e preparação para deploy em nuvem.
 
 ## Status
 
-O projeto esta em fase de planejamento. Neste momento, o repositorio prioriza alinhamento de produto, requisitos, arquitetura, riscos e estrategia de execucao antes do inicio da implementacao.
+O projeto já saiu da fase exclusivamente documental e entrou na construção da fundação técnica do backend.
 
-## Escopo Inicial
+Base implementada até aqui:
+- aplicação Spring Boot estruturada em estilo de monólito modular
+- módulo de identidade e acesso com `User`, `Role` e `RoleName`
+- persistência com Spring Data JPA
+- migração inicial do banco com Flyway
+- autenticação stateless com JWT
+- endpoints `POST /api/auth/login` e `GET /api/auth/me`
+- validação de entrada com Bean Validation
+- tratamento de erros básicos para autenticação e request inválido
+- endpoint operacional `GET /actuator/health`
 
-Fluxo principal previsto para o MVP:
+## Escopo do Produto
+
+Fluxo de negócio previsto para o MVP:
 
 ```text
-Requisicao de Compra -> Aprovacao -> Pedido de Compra -> Recebimento -> Entrada em Estoque -> Auditoria e Consulta
+Requisição de Compra -> Aprovação -> Pedido de Compra -> Recebimento -> Entrada em Estoque -> Auditoria e Consulta
 ```
 
-Capacidades previstas:
+Capacidades-alvo do sistema:
 - cadastro de produtos e fornecedores
-- requisicao de compra com aprovacao
+- requisição de compra com aprovação
 - pedido de compra e acompanhamento de recebimento
-- movimentacao e consulta de estoque
-- autenticacao, autorizacao e auditoria
-- frontend web acessivel
-- deploy em nuvem com esteira reprodutivel
+- movimentação e consulta de estoque
+- autenticação, autorização e auditoria
+- frontend web acessível
+- deploy em nuvem com esteira reprodutível
+
+## O Que Já Existe no Código
+
+O backend atual já demonstra uma base funcional de segurança e operação:
+- autenticação com email e senha
+- geração e validação de bearer token JWT
+- consulta ao usuário autenticado
+- bootstrap inicial de perfis e usuário administrador controlado por configuração
+- versionamento da estrutura de banco desde o início
+- health check para uso futuro em deploy, monitoramento e smoke tests
+
+Principais endpoints disponíveis hoje:
+
+```text
+POST /api/auth/login
+GET  /api/auth/me
+GET  /actuator/health
+```
+
+## Stack Atual
+
+Implementado neste estágio:
+- Java 17
+- Spring Boot
+- Spring Web
+- Spring Security
+- Spring Data JPA
+- Flyway
+- H2
+- Bean Validation
+- Spring Boot Actuator
+- JWT com `jjwt`
+
+Planejado para as próximas etapas:
+- PostgreSQL
+- Docker e Docker Compose
+- Terraform
+- Ansible
+- GitHub Actions
+- OVHcloud
+- observabilidade mais profunda
+- evolução para validação em Kubernetes
+
+## Execução Local
+
+Pré-requisitos:
+- Java 17
+- Maven
+
+Antes de subir a aplicação localmente, configure as variáveis de ambiente mínimas obrigatórias:
+
+- `JWT_SECRET`: segredo usado para assinar os tokens JWT. Deve ser um valor **Base64 válido** com pelo menos 32 bytes decodificados para HS256.
+- `IDENTITY_BOOTSTRAP_ADMIN_ENABLED=true`: habilita a criação do usuário administrador no bootstrap.
+- `IDENTITY_BOOTSTRAP_ADMIN_EMAIL`: email do admin inicial.
+- `IDENTITY_BOOTSTRAP_ADMIN_PASSWORD`: senha do admin inicial.
+- `IDENTITY_BOOTSTRAP_ADMIN_NAME`: nome do admin inicial. Opcional; se omitido, usa `Administrador`.
+
+Exemplo (Linux/macOS):
+
+```bash
+export JWT_SECRET="$(openssl rand -base64 32)"
+export IDENTITY_BOOTSTRAP_ADMIN_ENABLED=true
+export IDENTITY_BOOTSTRAP_ADMIN_EMAIL="admin@minierp.local"
+export IDENTITY_BOOTSTRAP_ADMIN_PASSWORD="<defina-uma-senha-local>"
+export IDENTITY_BOOTSTRAP_ADMIN_NAME="Administrador"
+mvn spring-boot:run
+```
+
+Exemplo (PowerShell):
+
+```powershell
+$bytes = New-Object byte[] 32
+[System.Security.Cryptography.RandomNumberGenerator]::Fill($bytes)
+$env:JWT_SECRET = [Convert]::ToBase64String($bytes)
+$env:IDENTITY_BOOTSTRAP_ADMIN_ENABLED="true"
+$env:IDENTITY_BOOTSTRAP_ADMIN_EMAIL="admin@minierp.local"
+$env:IDENTITY_BOOTSTRAP_ADMIN_PASSWORD="<defina-uma-senha-local>"
+$env:IDENTITY_BOOTSTRAP_ADMIN_NAME="Administrador"
+mvn spring-boot:run
+```
+
+> Em ambiente local, gere o `JWT_SECRET` dinamicamente e não versione segredos reais nem senhas de bootstrap.
+
+Health check:
+
+```bash
+curl http://localhost:8080/actuator/health
+```
+
+Login local:
+
+```bash
+curl -X POST http://localhost:8080/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"${IDENTITY_BOOTSTRAP_ADMIN_EMAIL}\",\"password\":\"${IDENTITY_BOOTSTRAP_ADMIN_PASSWORD}\"}"
+```
+
+Observação:
+o arquivo [application.properties](./src/main/resources/application.properties) não substitui a configuração mínima acima para o fluxo documentado no `README`. O arquivo [application-example.properties](./src/main/resources/application-example.properties) documenta o formato esperado para configuração externa por variáveis de ambiente.
 
 ## Foco de Engenharia
 
 O projeto foi desenhado para exercitar:
-- operacao de aplicacoes Java/Spring Boot em ambiente real
-- arquitetura de sistema corporativo pequeno com Java como linguagem principal
-- separacao entre produto, requisitos, arquitetura, dados, testes e riscos
-- padronizacao de fluxo local com `Make`
-- conteinerizacao com Docker
-- provisionamento com Terraform na OVHcloud
-- configuracao e deploy com Ansible
-- pipeline de CI/CD com GitHub Actions
-- observabilidade, troubleshooting, operacao e preocupacoes de acessibilidade desde o inicio
-- evolucao planejada de Docker Compose para Kubernetes
+- operação de aplicações Java/Spring Boot em ambiente real
+- organização modular de backend corporativo
+- autenticação, autorização e tratamento coerente de erros
+- versionamento de banco com migrações
+- health check e base operacional mínima
+- documentação antes e durante a implementação
+- evolução planejada para Docker, infraestrutura como código, CI/CD e cloud
 
-## Documentacao
+## Documentação
 
-A documentacao formal do projeto esta centralizada em [docs/README.md](./docs/README.md).
+A documentação formal do projeto está centralizada em [docs/README.md](./docs/README.md).
 
 Leitura recomendada:
-1. [Visao do Produto](./docs/01-visao-produto.md)
+1. [Visão do Produto](./docs/01-visao-produto.md)
 2. [Requisitos e Processos](./docs/02-requisitos-processos.md)
 3. [Arquitetura](./docs/03-arquitetura.md)
 4. [Dados e Qualidade](./docs/04-dados-qualidade.md)
-5. [Planejamento, Priorizacao e Riscos](./docs/05-planejamento-riscos.md)
-6. [Governanca de Agentes de IA](./docs/06-governanca-agentes-ia.md)
+5. [Planejamento, Priorização e Riscos](./docs/05-planejamento-riscos.md)
+6. [Governança de Agentes de IA](./docs/06-governanca-agentes-ia.md)
 7. [ADR-001](./docs/adr/ADR-001-monolito-modular-devops-first.md)
 8. [ADR-003](./docs/adr/ADR-003-adotar-governanca-tutor-first-para-agentes-de-ia.md)
 9. [ADR-004](./docs/adr/ADR-004-adotar-ovhcloud-single-host-com-evolucao-para-kubernetes.md)
 
-## Organizacao do Repositorio
+## Estrutura do Repositório
 
 ```text
 .
 |-- AGENTS.md
 |-- docs/
-|-- application/
-|-- entities/
-|-- README.md
-`-- roadmap-aprendizado.md
+|-- src/
+|   |-- main/
+|   |   |-- java/
+|   |   `-- resources/
+|-- pom.xml
+`-- README.md
 ```
 
-## Observacao
+## Próximos Passos
 
-O `README.md` da raiz funciona como a vitrine do repositorio: apresenta o projeto, o objetivo tecnico e os links principais.
+Próxima frente natural de evolução:
+- autorização por perfis em endpoints reais de negócio
+- início dos módulos de compras, recebimento e estoque
+- testes automatizados do fluxo de autenticação
+- troca do banco de desenvolvimento para algo mais próximo do ambiente-alvo
+- containerização e preparação de deploy
 
-O `docs/README.md` funciona como indice da documentacao oficial: organiza os artefatos de produto, requisitos, arquitetura, qualidade, planejamento e ADRs.
+O `README.md` da raiz funciona como a vitrine executiva e técnica do repositório.
 
-O `AGENTS.md` registra o contrato operacional para agentes de IA neste repositorio.
+O `docs/README.md` funciona como o índice da documentação oficial.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,100 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>br.com.diegosantos</groupId>
+    <artifactId>minierp</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>minierp</name>
+    <description>Mini ERP modular</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.3.2</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.11.5</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/br/com/diegosantos/minierp/MiniErpApplication.java
+++ b/src/main/java/br/com/diegosantos/minierp/MiniErpApplication.java
@@ -1,0 +1,12 @@
+package br.com.diegosantos.minierp;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class MiniErpApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(MiniErpApplication.class, args);
+    }
+}

--- a/src/main/java/br/com/diegosantos/minierp/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/br/com/diegosantos/minierp/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,46 @@
+package br.com.diegosantos.minierp.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.OffsetDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(InvalidCredentialsException.class)
+    public ResponseEntity<Map<String, Object>> handleInvalidCredentials(InvalidCredentialsException ex) {
+        Map<String, Object> body = Map.of(
+                "timestamp", OffsetDateTime.now(),
+                "status", HttpStatus.UNAUTHORIZED.value(),
+                "error", "Unauthorized",
+                "message", ex.getMessage()
+        );
+
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(body);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, Object>> handleValidation(MethodArgumentNotValidException ex) {
+        Map<String, String> fieldErrors = new LinkedHashMap<>();
+
+        ex.getBindingResult().getFieldErrors().forEach(error ->
+                fieldErrors.put(error.getField(), error.getDefaultMessage())
+        );
+
+        Map<String, Object> body = Map.of(
+                "timestamp", OffsetDateTime.now(),
+                "status", HttpStatus.BAD_REQUEST.value(),
+                "error", "Bad Request",
+                "message", "Dados de entrada inválidos",
+                "fields", fieldErrors
+        );
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
+}

--- a/src/main/java/br/com/diegosantos/minierp/common/exception/InvalidCredentialsException.java
+++ b/src/main/java/br/com/diegosantos/minierp/common/exception/InvalidCredentialsException.java
@@ -1,0 +1,8 @@
+package br.com.diegosantos.minierp.common.exception;
+
+public class InvalidCredentialsException extends RuntimeException {
+
+    public InvalidCredentialsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/br/com/diegosantos/minierp/identity/api/AuthController.java
+++ b/src/main/java/br/com/diegosantos/minierp/identity/api/AuthController.java
@@ -1,0 +1,44 @@
+package br.com.diegosantos.minierp.identity.api;
+
+import br.com.diegosantos.minierp.identity.api.dto.LoginRequest;
+import br.com.diegosantos.minierp.identity.api.dto.LoginResponse;
+import br.com.diegosantos.minierp.identity.api.dto.MeResponse;
+import br.com.diegosantos.minierp.identity.application.AuthenticateUserService;
+import br.com.diegosantos.minierp.identity.application.GetCurrentUserService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthenticateUserService authenticateUserService;
+    private final GetCurrentUserService getCurrentUserService;
+
+    public AuthController(
+            AuthenticateUserService authenticateUserService,
+            GetCurrentUserService getCurrentUserService
+    ) {
+        this.authenticateUserService = authenticateUserService;
+        this.getCurrentUserService = getCurrentUserService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
+        LoginResponse response = authenticateUserService.execute(
+                request.getEmail(),
+                request.getPassword()
+        );
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<MeResponse> me(@AuthenticationPrincipal UserDetails userDetails) {
+        MeResponse response = getCurrentUserService.execute(userDetails.getUsername());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/br/com/diegosantos/minierp/identity/api/dto/LoginRequest.java
+++ b/src/main/java/br/com/diegosantos/minierp/identity/api/dto/LoginRequest.java
@@ -1,0 +1,33 @@
+package br.com.diegosantos.minierp.identity.api.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public class LoginRequest {
+
+    @NotBlank(message = "Email é obrigatório")
+    @Email(message = "Email deve ter um formato válido")
+    private String email;
+
+    @NotBlank(message = "Senha é obrigatória")
+    private String password;
+
+    public LoginRequest() {
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/main/java/br/com/diegosantos/minierp/identity/api/dto/LoginResponse.java
+++ b/src/main/java/br/com/diegosantos/minierp/identity/api/dto/LoginResponse.java
@@ -1,0 +1,31 @@
+package br.com.diegosantos.minierp.identity.api.dto;
+
+import java.time.OffsetDateTime;
+
+public class LoginResponse {
+
+    private String token;
+    private String type;
+    private OffsetDateTime expiresAt;
+
+    public LoginResponse() {
+    }
+
+    public LoginResponse(String token, String type, OffsetDateTime expiresAt) {
+        this.token = token;
+        this.type = type;
+        this.expiresAt = expiresAt;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public OffsetDateTime getExpiresAt() {
+        return expiresAt;
+    }
+}

--- a/src/main/java/br/com/diegosantos/minierp/identity/api/dto/MeResponse.java
+++ b/src/main/java/br/com/diegosantos/minierp/identity/api/dto/MeResponse.java
@@ -1,0 +1,34 @@
+package br.com.diegosantos.minierp.identity.api.dto;
+
+import java.util.Set;
+
+public class MeResponse {
+
+    private Long id;
+    private String nome;
+    private String email;
+    private Set<String> roles;
+
+    public MeResponse(Long id, String nome, String email, Set<String> roles) {
+        this.id = id;
+        this.nome = nome;
+        this.email = email;
+        this.roles = roles;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public Set<String> getRoles() {
+        return roles;
+    }
+}

--- a/src/main/java/br/com/diegosantos/minierp/identity/application/AuthenticateUserService.java
+++ b/src/main/java/br/com/diegosantos/minierp/identity/application/AuthenticateUserService.java
@@ -1,0 +1,48 @@
+package br.com.diegosantos.minierp.identity.application;
+
+import br.com.diegosantos.minierp.common.exception.InvalidCredentialsException;
+import br.com.diegosantos.minierp.identity.api.dto.LoginResponse;
+import br.com.diegosantos.minierp.identity.domain.User;
+import br.com.diegosantos.minierp.identity.infrastructure.persistence.UserRepository;
+import br.com.diegosantos.minierp.identity.infrastructure.security.JwtService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthenticateUserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtService jwtService;
+
+    public AuthenticateUserService(
+            UserRepository userRepository,
+            PasswordEncoder passwordEncoder,
+            JwtService jwtService
+    ) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtService = jwtService;
+    }
+
+    public LoginResponse execute(String email, String password) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new InvalidCredentialsException("Credenciais inválidas"));
+
+        if (!user.isAtivo()) {
+            throw new InvalidCredentialsException("Usuário inativo");
+        }
+
+        if (!passwordEncoder.matches(password, user.getPasswordHash())) {
+            throw new InvalidCredentialsException("Credenciais inválidas");
+        }
+
+        String token = jwtService.generateToken(user.getEmail());
+
+        return new LoginResponse(
+                token,
+                "Bearer",
+                jwtService.extractExpiration(token)
+        );
+    }
+}

--- a/src/main/java/br/com/diegosantos/minierp/identity/application/GetCurrentUserService.java
+++ b/src/main/java/br/com/diegosantos/minierp/identity/application/GetCurrentUserService.java
@@ -1,0 +1,43 @@
+package br.com.diegosantos.minierp.identity.application;
+
+import br.com.diegosantos.minierp.identity.api.dto.MeResponse;
+import br.com.diegosantos.minierp.identity.domain.User;
+import br.com.diegosantos.minierp.identity.infrastructure.persistence.UserRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class GetCurrentUserService {
+
+    private final UserRepository userRepository;
+
+    public GetCurrentUserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public MeResponse execute(String email) {
+        User user = userRepository.findWithRolesByEmail(email)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.UNAUTHORIZED,
+                        "Usuário autenticado não encontrado"
+                ));
+
+        Set<String> roles = user.getRoles()
+                .stream()
+                .map(role -> role.getName().name())
+                .collect(Collectors.toSet());
+
+        return new MeResponse(
+                user.getId(),
+                user.getNome(),
+                user.getEmail(),
+                roles
+        );
+    }
+}

--- a/src/main/java/br/com/diegosantos/minierp/identity/domain/Role.java
+++ b/src/main/java/br/com/diegosantos/minierp/identity/domain/Role.java
@@ -1,0 +1,31 @@
+package br.com.diegosantos.minierp.identity.domain;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "roles")
+public class Role {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "name", nullable = false, unique = true, length = 50)
+    private RoleName name;
+
+    protected Role() {
+    }
+
+    public Role(RoleName name) {
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public RoleName getName() {
+        return name;
+    }
+}

--- a/src/main/java/br/com/diegosantos/minierp/identity/domain/RoleName.java
+++ b/src/main/java/br/com/diegosantos/minierp/identity/domain/RoleName.java
@@ -1,0 +1,10 @@
+package br.com.diegosantos.minierp.identity.domain;
+
+public enum RoleName {
+    ADMIN,
+    SOLICITANTE,
+    APROVADOR,
+    COMPRADOR,
+    ALMOXARIFE,
+    GESTOR
+}

--- a/src/main/java/br/com/diegosantos/minierp/identity/domain/User.java
+++ b/src/main/java/br/com/diegosantos/minierp/identity/domain/User.java
@@ -1,0 +1,95 @@
+package br.com.diegosantos.minierp.identity.domain;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "nome", nullable = false, length = 120)
+    private String nome;
+
+    @Column(name = "email", nullable = false, unique = true, length = 160)
+    private String email;
+
+    @Column(name = "password_hash", nullable = false, length = 255)
+    private String passwordHash;
+
+    @Column(name = "ativo", nullable = false)
+    private boolean ativo = true;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+            name = "users_roles",
+            joinColumns = @JoinColumn(name = "user_id"),
+            inverseJoinColumns = @JoinColumn(name = "role_id")
+    )
+    private Set<Role> roles = new HashSet<>();
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    protected User() {
+    }
+
+    public User(String nome, String email, String passwordHash) {
+        this.nome = nome;
+        this.email = email;
+        this.passwordHash = passwordHash;
+        this.ativo = true;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getPasswordHash() {
+        return passwordHash;
+    }
+
+    public boolean isAtivo() {
+        return ativo;
+    }
+
+    public Set<Role> getRoles() {
+        return roles;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/src/main/java/br/com/diegosantos/minierp/identity/infrastructure/bootstrap/IdentityBootstrap.java
+++ b/src/main/java/br/com/diegosantos/minierp/identity/infrastructure/bootstrap/IdentityBootstrap.java
@@ -1,0 +1,110 @@
+package br.com.diegosantos.minierp.identity.infrastructure.bootstrap;
+
+import br.com.diegosantos.minierp.identity.domain.Role;
+import br.com.diegosantos.minierp.identity.domain.RoleName;
+import br.com.diegosantos.minierp.identity.domain.User;
+import br.com.diegosantos.minierp.identity.infrastructure.persistence.RoleRepository;
+import br.com.diegosantos.minierp.identity.infrastructure.persistence.UserRepository;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+@Component
+public class IdentityBootstrap implements CommandLineRunner {
+
+    private final RoleRepository roleRepository;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final boolean adminBootstrapEnabled;
+    private final String adminName;
+    private final String adminEmail;
+    private final String adminPassword;
+
+    public IdentityBootstrap(
+            RoleRepository roleRepository,
+            UserRepository userRepository,
+            PasswordEncoder passwordEncoder,
+            @Value("${identity.bootstrap.admin.enabled:false}") boolean adminBootstrapEnabled,
+            @Value("${identity.bootstrap.admin.name:Administrador}") String adminName,
+            @Value("${identity.bootstrap.admin.email:}") String adminEmail,
+            @Value("${identity.bootstrap.admin.password:}") String adminPassword
+    ) {
+        this.roleRepository = roleRepository;
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.adminBootstrapEnabled = adminBootstrapEnabled;
+        this.adminName = adminName;
+        this.adminEmail = adminEmail;
+        this.adminPassword = adminPassword;
+    }
+
+    @Override
+    public void run(String... args) {
+        ensureRoleExists(RoleName.ADMIN);
+        ensureRoleExists(RoleName.SOLICITANTE);
+        ensureRoleExists(RoleName.APROVADOR);
+        ensureRoleExists(RoleName.COMPRADOR);
+        ensureRoleExists(RoleName.ALMOXARIFE);
+        ensureRoleExists(RoleName.GESTOR);
+
+        if (!adminBootstrapEnabled) {
+            return;
+        }
+
+        validateAdminBootstrapConfiguration();
+        ensureAdminExists();
+    }
+
+    private void ensureRoleExists(RoleName roleName) {
+        if (roleRepository.findByName(roleName).isEmpty()) {
+            try {
+                roleRepository.save(new Role(roleName));
+            } catch (DataIntegrityViolationException ex) {
+                if (roleRepository.findByName(roleName).isEmpty()) {
+                    throw ex;
+                }
+            }
+        }
+    }
+
+    private void ensureAdminExists() {
+        if (userRepository.findByEmail(adminEmail).isPresent()) {
+            return;
+        }
+
+        Role adminRole = roleRepository.findByName(RoleName.ADMIN)
+                .orElseThrow(() -> new IllegalStateException("Role ADMIN não encontrada"));
+
+        User admin = new User(
+                adminName,
+                adminEmail,
+                passwordEncoder.encode(adminPassword)
+        );
+
+        admin.getRoles().add(adminRole);
+
+        try {
+            userRepository.save(admin);
+        } catch (DataIntegrityViolationException ex) {
+            if (userRepository.findByEmail(adminEmail).isEmpty()) {
+                throw ex;
+            }
+        }
+    }
+
+    private void validateAdminBootstrapConfiguration() {
+        if (isBlank(adminEmail) || isBlank(adminPassword)) {
+            throw new IllegalStateException(
+                    "Configure identity.bootstrap.admin.email e identity.bootstrap.admin.password para habilitar o bootstrap do admin"
+            );
+        }
+    }
+
+    private boolean isBlank(String value) {
+        return Objects.isNull(value) || value.isBlank();
+    }
+}

--- a/src/main/java/br/com/diegosantos/minierp/identity/infrastructure/persistence/RoleRepository.java
+++ b/src/main/java/br/com/diegosantos/minierp/identity/infrastructure/persistence/RoleRepository.java
@@ -1,0 +1,11 @@
+package br.com.diegosantos.minierp.identity.infrastructure.persistence;
+
+import br.com.diegosantos.minierp.identity.domain.Role;
+import br.com.diegosantos.minierp.identity.domain.RoleName;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RoleRepository extends JpaRepository<Role, Long> {
+    Optional<Role> findByName(RoleName name);
+}

--- a/src/main/java/br/com/diegosantos/minierp/identity/infrastructure/persistence/UserRepository.java
+++ b/src/main/java/br/com/diegosantos/minierp/identity/infrastructure/persistence/UserRepository.java
@@ -1,0 +1,15 @@
+package br.com.diegosantos.minierp.identity.infrastructure.persistence;
+
+import br.com.diegosantos.minierp.identity.domain.User;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+
+    @EntityGraph(attributePaths = "roles")
+    Optional<User> findWithRolesByEmail(String email);
+}

--- a/src/main/java/br/com/diegosantos/minierp/identity/infrastructure/security/CustomUserDetailsService.java
+++ b/src/main/java/br/com/diegosantos/minierp/identity/infrastructure/security/CustomUserDetailsService.java
@@ -1,0 +1,49 @@
+package br.com.diegosantos.minierp.identity.infrastructure.security;
+
+import br.com.diegosantos.minierp.identity.domain.Role;
+import br.com.diegosantos.minierp.identity.domain.User;
+import br.com.diegosantos.minierp.identity.infrastructure.persistence.UserRepository;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findWithRolesByEmail(username)
+                .orElseThrow(() -> new UsernameNotFoundException("Usuário não encontrado: " + username));
+
+        return new org.springframework.security.core.userdetails.User(
+                user.getEmail(),
+                user.getPasswordHash(),
+                user.isAtivo(),
+                true,
+                true,
+                true,
+                mapRolesToAuthorities(user)
+        );
+    }
+
+    private Collection<? extends GrantedAuthority> mapRolesToAuthorities(User user) {
+        return user.getRoles()
+                .stream()
+                .map(Role::getName)
+                .map(Enum::name)
+                .map(roleName -> new SimpleGrantedAuthority("ROLE_" + roleName))
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/br/com/diegosantos/minierp/identity/infrastructure/security/JwtAuthenticationFilter.java
+++ b/src/main/java/br/com/diegosantos/minierp/identity/infrastructure/security/JwtAuthenticationFilter.java
@@ -1,0 +1,78 @@
+package br.com.diegosantos.minierp.identity.infrastructure.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import io.jsonwebtoken.JwtException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+    private final UserDetailsService userDetailsService;
+
+    public JwtAuthenticationFilter(JwtService jwtService, UserDetailsService userDetailsService) {
+        this.jwtService = jwtService;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        final String authHeader = request.getHeader("Authorization");
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String jwt = authHeader.substring(7);
+        try {
+            String username = jwtService.extractUsername(jwt);
+
+            if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+
+                if (!userDetails.isEnabled()) {
+                    SecurityContextHolder.clearContext();
+                    response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Usuario inativo");
+                    return;
+                }
+
+                if (jwtService.isTokenValid(jwt, userDetails.getUsername())) {
+                    UsernamePasswordAuthenticationToken authenticationToken =
+                            new UsernamePasswordAuthenticationToken(
+                                    userDetails,
+                                    null,
+                                    userDetails.getAuthorities()
+                            );
+
+                    authenticationToken.setDetails(
+                            new WebAuthenticationDetailsSource().buildDetails(request)
+                    );
+
+                    SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+                }
+            }
+        } catch (JwtException | IllegalArgumentException | UsernameNotFoundException ex) {
+            SecurityContextHolder.clearContext();
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/br/com/diegosantos/minierp/identity/infrastructure/security/JwtAuthenticationFilter.java
+++ b/src/main/java/br/com/diegosantos/minierp/identity/infrastructure/security/JwtAuthenticationFilter.java
@@ -50,7 +50,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 if (!userDetails.isEnabled()) {
                     SecurityContextHolder.clearContext();
-                    response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Usuario inativo");
+                    response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Usuário inativo");
                     return;
                 }
 

--- a/src/main/java/br/com/diegosantos/minierp/identity/infrastructure/security/JwtService.java
+++ b/src/main/java/br/com/diegosantos/minierp/identity/infrastructure/security/JwtService.java
@@ -8,7 +8,7 @@ import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;

--- a/src/main/java/br/com/diegosantos/minierp/identity/infrastructure/security/JwtService.java
+++ b/src/main/java/br/com/diegosantos/minierp/identity/infrastructure/security/JwtService.java
@@ -1,0 +1,108 @@
+package br.com.diegosantos.minierp.identity.infrastructure.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Date;
+
+@Service
+public class JwtService {
+
+    private static final int HS256_MIN_KEY_BYTES = 32;
+
+    @Value("${security.jwt.secret}")
+    private String jwtSecret;
+
+    @Value("${security.jwt.expiration}")
+    private long jwtExpirationInSeconds;
+
+    private SecretKey signingKey;
+
+    @PostConstruct
+    private void initializeSigningKey() {
+        this.signingKey = buildSigningKey(jwtSecret);
+    }
+
+    public String generateToken(String subject) {
+        Instant now = Instant.now();
+        Instant expiration = now.plusSeconds(jwtExpirationInSeconds);
+
+        return Jwts.builder()
+                .setSubject(subject)
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(expiration))
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String extractUsername(String token) {
+        return extractAllClaims(token).getSubject();
+    }
+
+    public OffsetDateTime extractExpiration(String token) {
+        Date expiration = extractAllClaims(token).getExpiration();
+        return OffsetDateTime.ofInstant(expiration.toInstant(), ZoneOffset.UTC);
+    }
+
+    public boolean isTokenValid(String token, String expectedUsername) {
+        Claims claims = extractAllClaims(token);
+        String username = claims.getSubject();
+        return expectedUsername != null
+                && expectedUsername.equals(username)
+                && !isTokenExpired(claims);
+    }
+
+    private boolean isTokenExpired(Claims claims) {
+        return claims.getExpiration().before(new Date());
+    }
+
+    private Claims extractAllClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    private SecretKey buildSigningKey(String secret) {
+        if (secret == null || secret.trim().isEmpty()) {
+            throw new IllegalStateException(
+                    "Invalid JWT configuration: 'security.jwt.secret' must be configured and must not be blank. " +
+                    "Provide a Base64-encoded secret or a plain text secret with at least 32 bytes for HS256."
+            );
+        }
+
+        String normalizedSecret = secret.trim();
+        byte[] keyBytes;
+
+        try {
+            keyBytes = Decoders.BASE64.decode(normalizedSecret);
+        } catch (IllegalArgumentException ex) {
+            keyBytes = normalizedSecret.getBytes(StandardCharsets.UTF_8);
+        }
+
+        if (keyBytes.length < HS256_MIN_KEY_BYTES) {
+            throw new IllegalStateException(
+                    "Invalid JWT configuration: 'security.jwt.secret' must decode to at least 32 bytes for HS256. " +
+                    "Configure JWT_SECRET as a Base64-encoded 32-byte+ key or use a plain text secret with at least 32 characters."
+            );
+        }
+
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    private SecretKey getSigningKey() {
+        return signingKey;
+    }
+}

--- a/src/main/java/br/com/diegosantos/minierp/identity/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/br/com/diegosantos/minierp/identity/infrastructure/security/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
                                 writeJsonError(
                                         response,
                                         HttpServletResponse.SC_UNAUTHORIZED,
-                                        "Token ausente, invalido ou expirado"
+                                        "Token ausente, inválido ou expirado"
                                 )
                         )
                         .accessDeniedHandler((request, response, ex) ->

--- a/src/main/java/br/com/diegosantos/minierp/identity/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/br/com/diegosantos/minierp/identity/infrastructure/security/SecurityConfig.java
@@ -1,0 +1,87 @@
+package br.com.diegosantos.minierp.identity.infrastructure.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .exceptionHandling(exceptions -> exceptions
+                        .authenticationEntryPoint((request, response, ex) ->
+                                writeJsonError(
+                                        response,
+                                        HttpServletResponse.SC_UNAUTHORIZED,
+                                        "Token ausente, invalido ou expirado"
+                                )
+                        )
+                        .accessDeniedHandler((request, response, ex) ->
+                                writeJsonError(
+                                        response,
+                                        HttpServletResponse.SC_FORBIDDEN,
+                                        "Acesso negado"
+                                )
+                        )
+                )
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/error",
+                                "/api/auth/login",
+                                "/actuator/health"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .httpBasic(httpBasic -> httpBasic.disable())
+                .formLogin(formLogin -> formLogin.disable())
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    private void writeJsonError(HttpServletResponse response, int status, String message) throws IOException {
+        response.setStatus(status);
+        response.setContentType("application/json");
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("timestamp", Instant.now().toString());
+        body.put("status", status);
+        body.put("error", status == HttpServletResponse.SC_UNAUTHORIZED ? "Unauthorized" : "Forbidden");
+        body.put("message", message);
+
+        new ObjectMapper().writeValue(response.getWriter(), body);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/resources/application-example.properties
+++ b/src/main/resources/application-example.properties
@@ -1,0 +1,10 @@
+spring.application.name=minierp
+security.jwt.secret=${JWT_SECRET}
+security.jwt.expiration=${JWT_EXPIRATION:3600}
+management.endpoints.web.exposure.include=health,info
+management.endpoint.health.show-details=never
+
+identity.bootstrap.admin.enabled=${IDENTITY_BOOTSTRAP_ADMIN_ENABLED:false}
+identity.bootstrap.admin.name=${IDENTITY_BOOTSTRAP_ADMIN_NAME:Administrador}
+identity.bootstrap.admin.email=${IDENTITY_BOOTSTRAP_ADMIN_EMAIL:}
+identity.bootstrap.admin.password=${IDENTITY_BOOTSTRAP_ADMIN_PASSWORD:}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,10 @@
+spring.application.name=minierp
+security.jwt.secret=${JWT_SECRET}
+security.jwt.expiration=${JWT_EXPIRATION:3600}
+management.endpoints.web.exposure.include=health,info
+management.endpoint.health.show-details=never
+
+identity.bootstrap.admin.enabled=${IDENTITY_BOOTSTRAP_ADMIN_ENABLED:false}
+identity.bootstrap.admin.name=${IDENTITY_BOOTSTRAP_ADMIN_NAME:Administrador}
+identity.bootstrap.admin.email=${IDENTITY_BOOTSTRAP_ADMIN_EMAIL:}
+identity.bootstrap.admin.password=${IDENTITY_BOOTSTRAP_ADMIN_PASSWORD:}

--- a/src/main/resources/db/migration/V1__create_identity_tables.sql
+++ b/src/main/resources/db/migration/V1__create_identity_tables.sql
@@ -1,0 +1,24 @@
+CREATE TABLE roles (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name VARCHAR(50) NOT NULL UNIQUE
+);
+
+CREATE TABLE users (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    nome VARCHAR(120) NOT NULL,
+    email VARCHAR(160) NOT NULL UNIQUE,
+    password_hash VARCHAR(255) NOT NULL,
+    ativo BOOLEAN NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL
+);
+
+CREATE TABLE users_roles (
+    user_id BIGINT NOT NULL,
+    role_id BIGINT NOT NULL,
+    PRIMARY KEY (user_id, role_id),
+    CONSTRAINT fk_users_roles_user
+        FOREIGN KEY (user_id) REFERENCES users(id),
+    CONSTRAINT fk_users_roles_role
+        FOREIGN KEY (role_id) REFERENCES roles(id)
+);


### PR DESCRIPTION
## Contexto

Esta PR estabelece a fundação técnica inicial do backend do Mini-ERP, com foco em identidade, autenticação, persistência versionada e health check.

## O que foi implementado

- estrutura inicial do backend em Java 17 com Spring Boot
- organização em estilo de monólito modular
- módulo de identidade com `User`, `Role` e `RoleName`
- persistência com Spring Data JPA
- migração inicial com Flyway
- autenticação stateless com JWT
- endpoints:
  - `POST /api/auth/login`
  - `GET /api/auth/me`
- validação de entrada com Bean Validation
- tratamento de erros básicos
- endpoint `GET /actuator/health`
- documentação atualizada no README

## Validação

Fluxos validados manualmente:
- `/actuator/health` -> `200`
- `/api/auth/login` -> `200`
- `/api/auth/me` com token válido -> `200`
- `/api/auth/me` sem token -> `401`
- `/api/auth/me` com token inválido -> `401`

## Observação

Esta PR substitui a anterior, que foi recriada a partir de `main` para remover do histórico da PR commits que continham segredos expostos em ambiente de desenvolvimento.
