### PR TITLE
chore(devex): adicionar lint, pre-commit e prevenção de segredos hardcoded

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - "feature/**"
+      - "test/**"
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Run CI workflow
+        run: make ci

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+default_install_hook_types:
+  - pre-commit
+  - pre-push
+
+repos:
+  - repo: local
+    hooks:
+      - id: lint-secrets
+        name: lint-secrets
+        entry: make lint-secrets
+        language: system
+        pass_filenames: false
+        stages:
+          - pre-commit
+
+      - id: lint-java
+        name: lint-java
+        entry: make lint-java
+        language: system
+        pass_filenames: false
+        stages:
+          - pre-commit
+
+      - id: ci-pre-push
+        name: ci-pre-push
+        entry: make ci
+        language: system
+        pass_filenames: false
+        stages:
+          - pre-push

--- a/Makefile
+++ b/Makefile
@@ -2,19 +2,33 @@ SHELL := /bin/bash
 
 MVN ?= mvn
 MAVEN_FLAGS ?= -B -ntp
+PRE_COMMIT ?= pre-commit
 
-.PHONY: help clean test package run ci
+.PHONY: help clean lint lint-java lint-secrets test package run ci pre-commit-install pre-commit-run
 
 help:
 	@echo "Targets disponiveis:"
 	@echo "  make clean   - limpa artefatos locais do Maven"
+	@echo "  make lint    - executa validacoes rapidas de codigo e segredos"
+	@echo "  make lint-java - compila o codigo sem rodar os testes"
+	@echo "  make lint-secrets - procura credenciais e segredos hardcoded"
 	@echo "  make test    - executa a suite automatizada"
 	@echo "  make package - gera o artefato da aplicacao"
 	@echo "  make run     - sobe a aplicacao Spring Boot localmente"
 	@echo "  make ci      - executa o fluxo minimo usado pela pipeline"
+	@echo "  make pre-commit-install - instala hooks locais de pre-commit e pre-push"
+	@echo "  make pre-commit-run - executa os hooks em todos os arquivos"
 
 clean:
 	$(MVN) $(MAVEN_FLAGS) clean
+
+lint: lint-secrets lint-java
+
+lint-java:
+	$(MVN) $(MAVEN_FLAGS) -DskipTests compile
+
+lint-secrets:
+	bash scripts/check-no-hardcoded-secrets.sh
 
 test:
 	$(MVN) $(MAVEN_FLAGS) test
@@ -26,4 +40,11 @@ run:
 	$(MVN) spring-boot:run
 
 ci:
+	$(MAKE) lint
 	$(MVN) $(MAVEN_FLAGS) clean test
+
+pre-commit-install:
+	$(PRE_COMMIT) install --hook-type pre-commit --hook-type pre-push
+
+pre-commit-run:
+	$(PRE_COMMIT) run --all-files

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+SHELL := /bin/bash
+
+MVN ?= mvn
+MAVEN_FLAGS ?= -B -ntp
+
+.PHONY: help clean test package run ci
+
+help:
+	@echo "Targets disponiveis:"
+	@echo "  make clean   - limpa artefatos locais do Maven"
+	@echo "  make test    - executa a suite automatizada"
+	@echo "  make package - gera o artefato da aplicacao"
+	@echo "  make run     - sobe a aplicacao Spring Boot localmente"
+	@echo "  make ci      - executa o fluxo minimo usado pela pipeline"
+
+clean:
+	$(MVN) $(MAVEN_FLAGS) clean
+
+test:
+	$(MVN) $(MAVEN_FLAGS) test
+
+package:
+	$(MVN) $(MAVEN_FLAGS) clean package
+
+run:
+	$(MVN) spring-boot:run
+
+ci:
+	$(MVN) $(MAVEN_FLAGS) clean test

--- a/README.md
+++ b/README.md
@@ -146,9 +146,18 @@ curl http://localhost:8080/actuator/health
 Automação local com Make:
 
 ```bash
+make lint
 make run
 make test
 make ci
+```
+
+Pre-commit estruturado:
+
+```bash
+pip install pre-commit
+make pre-commit-install
+make pre-commit-run
 ```
 
 Login local:

--- a/README.md
+++ b/README.md
@@ -29,8 +29,11 @@ Base implementada até aqui:
 - autenticação stateless com JWT
 - endpoints `POST /api/auth/login` e `GET /api/auth/me`
 - validação de entrada com Bean Validation
-- tratamento de erros básicos para autenticação e request inválido
+- tratamento coerente de erros para autenticação e request inválido
 - endpoint operacional `GET /actuator/health`
+- testes automatizados da fundação de autenticação e health
+- automação local com `Makefile`
+- pipeline inicial de CI com GitHub Actions
 
 ## Escopo do Produto
 
@@ -58,6 +61,8 @@ O backend atual já demonstra uma base funcional de segurança e operação:
 - bootstrap inicial de perfis e usuário administrador controlado por configuração
 - versionamento da estrutura de banco desde o início
 - health check para uso futuro em deploy, monitoramento e smoke tests
+- contrato consistente de `401` para falhas de autenticação no fluxo protegido
+- cobertura automatizada do fluxo mínimo de autenticação
 
 Principais endpoints disponíveis hoje:
 
@@ -80,13 +85,14 @@ Implementado neste estágio:
 - Bean Validation
 - Spring Boot Actuator
 - JWT com `jjwt`
+- Makefile
+- GitHub Actions CI inicial
 
 Planejado para as próximas etapas:
 - PostgreSQL
 - Docker e Docker Compose
 - Terraform
 - Ansible
-- GitHub Actions
 - OVHcloud
 - observabilidade mais profunda
 - evolução para validação em Kubernetes
@@ -137,6 +143,14 @@ Health check:
 curl http://localhost:8080/actuator/health
 ```
 
+Automação local com Make:
+
+```bash
+make run
+make test
+make ci
+```
+
 Login local:
 
 ```bash
@@ -170,9 +184,10 @@ Leitura recomendada:
 4. [Dados e Qualidade](./docs/04-dados-qualidade.md)
 5. [Planejamento, Priorização e Riscos](./docs/05-planejamento-riscos.md)
 6. [Governança de Agentes de IA](./docs/06-governanca-agentes-ia.md)
-7. [ADR-001](./docs/adr/ADR-001-monolito-modular-devops-first.md)
-8. [ADR-003](./docs/adr/ADR-003-adotar-governanca-tutor-first-para-agentes-de-ia.md)
-9. [ADR-004](./docs/adr/ADR-004-adotar-ovhcloud-single-host-com-evolucao-para-kubernetes.md)
+7. [Observabilidade e Operação](./docs/07-observabilidade-operacao.md)
+8. [ADR-001](./docs/adr/ADR-001-monolito-modular-devops-first.md)
+9. [ADR-003](./docs/adr/ADR-003-adotar-governanca-tutor-first-para-agentes-de-ia.md)
+10. [ADR-004](./docs/adr/ADR-004-adotar-ovhcloud-single-host-com-evolucao-para-kubernetes.md)
 
 ## Estrutura do Repositório
 
@@ -180,6 +195,8 @@ Leitura recomendada:
 .
 |-- AGENTS.md
 |-- docs/
+|-- .github/
+|-- Makefile
 |-- src/
 |   |-- main/
 |   |   |-- java/
@@ -193,7 +210,7 @@ Leitura recomendada:
 Próxima frente natural de evolução:
 - autorização por perfis em endpoints reais de negócio
 - início dos módulos de compras, recebimento e estoque
-- testes automatizados do fluxo de autenticação
+- logs estruturados e runbooks básicos de troubleshooting
 - troca do banco de desenvolvimento para algo mais próximo do ambiente-alvo
 - containerização e preparação de deploy
 

--- a/docs/03-arquitetura.md
+++ b/docs/03-arquitetura.md
@@ -160,11 +160,16 @@ Responsabilidades do `Makefile`:
 - encapsular comandos de Docker, Terraform e Ansible
 - reduzir variacao de uso entre ambientes
 
+Comandos iniciais implementados:
+- `make help`
+- `make clean`
+- `make run`
+- `make test`
+- `make package`
+- `make ci`
+
 Comandos esperados futuramente:
 - `make dev`
-- `make test`
-- `make lint`
-- `make build`
 - `make docker-build`
 - `make infra-plan`
 - `make infra-apply`
@@ -173,7 +178,13 @@ Comandos esperados futuramente:
 
 ### CI/CD
 
-Esteira desejada:
+Esteira atual:
+1. checkout do repositorio
+2. setup do Java 17
+3. execucao de `make ci`
+4. validacao automatica da fundacao tecnica do backend
+
+Esteira desejada para evolucao:
 1. validacao de formato e qualidade
 2. build do backend Spring Boot e do frontend
 3. execucao de testes automatizados
@@ -193,6 +204,9 @@ Capacidades desejadas:
 - correlacao de eventos de auditoria com acoes de negocio
 - estrategia de analise de falhas de startup, memoria, timeout e latencia
 - runbooks curtos para incidentes comuns
+
+Referencia detalhada:
+- [07-observabilidade-operacao.md](./07-observabilidade-operacao.md)
 
 ### Seguranca
 
@@ -233,7 +247,6 @@ Artefatos esperados ao longo da implementacao:
 
 - framework do frontend
 - estrategia de autenticacao inicial
-- profundidade de observabilidade do MVP
 - ponto exato de entrada da validacao em Kubernetes
 
 ## 10. Criterios de aceitacao arquitetural

--- a/docs/07-observabilidade-operacao.md
+++ b/docs/07-observabilidade-operacao.md
@@ -1,0 +1,133 @@
+# Observabilidade e Operacao
+
+## 1. Objetivo do documento
+
+Definir a estrategia inicial de observabilidade, diagnostico e troubleshooting do MVP, conectando a implementacao atual do backend com a futura operacao em ambiente Linux e OVHcloud.
+
+## 2. Principios adotados
+
+- observabilidade faz parte da arquitetura, nao entra apenas no deploy
+- o MVP deve ser operavel mesmo antes de existir uma stack completa de monitoramento
+- logs, health checks e testes de smoke devem produzir evidencias claras para diagnostico
+- o ambiente remoto deve privilegiar simplicidade operacional e baixo custo
+- toda capacidade operacional precisa ser explicavel e reproduzivel
+
+## 3. Estado atual da fundacao tecnica
+
+Capacidades ja presentes no repositorio:
+- endpoint `GET /actuator/health`
+- autenticacao JWT com respostas `401` coerentes no fluxo protegido
+- tratamento padronizado de erros de autenticacao e validacao
+- testes automatizados da fundacao de autenticacao e health check
+- automacao local com `Makefile`
+- pipeline inicial de CI com build e testes
+
+Limite atual:
+- ainda nao existe agregacao centralizada de logs
+- ainda nao existem metricas de negocio ou dashboards
+- ainda nao existe tracing distribuido
+- ainda nao existem runbooks versionados fora deste documento
+
+## 4. Estrategia inicial do MVP
+
+### 4.1 Logs
+
+Direcao inicial:
+- a aplicacao deve escrever logs em `stdout`
+- o container e o runtime do host serao a fonte primaria de coleta
+- erros de autenticacao, falhas de startup e exceptions precisam ser compreensiveis
+- logs devem permitir diagnostico de configuracao, porta, conectividade e falha de request
+
+Padrao operacional inicial:
+- ambiente local: leitura direta no terminal
+- ambiente remoto inicial: leitura via logs do processo ou do container
+- proxy reverso: logs de acesso e erro separados da aplicacao
+
+Evolucao planejada:
+- adotar logs estruturados em JSON
+- adicionar correlacao basica por request
+- separar eventos tecnicos de eventos de auditoria de negocio
+
+### 4.2 Health checks
+
+Direcao inicial:
+- `GET /actuator/health` sera o endpoint minimo de saude tecnica
+- smoke tests locais, CI e deploy devem validar esse endpoint
+- health check deve ser usado como evidencia de startup bem-sucedido
+
+Uso esperado:
+- local: validacao rapida apos `make run`
+- pipeline: smoke tecnico antes de ampliar a esteira
+- deploy em OVHcloud: verificacao de disponibilidade da aplicacao
+
+Evolucao planejada:
+- diferenciar readiness e liveness quando a topologia exigir
+- incluir dependencias relevantes, como banco, em checagens mais detalhadas
+- preparar probes para a trilha futura em Kubernetes
+
+### 4.3 Metricas
+
+Direcao inicial:
+- comecar por metricas tecnicas simples antes de metricas de negocio
+- priorizar disponibilidade, taxa de erro e tempo de resposta
+- evitar expor endpoints operacionais desnecessarios em ambiente publico sem protecao
+
+Metrica minima desejada no proximo passo:
+- latencia basica de requests
+- contagem de erros HTTP por classe
+- tempo de inicializacao da aplicacao
+- consumo basico de recursos do host e dos containers
+
+Evolucao planejada:
+- integrar Micrometer com stack de coleta adequada ao ambiente
+- definir paines simples para health, erros e latencia
+- introduzir metricas de dominio quando os modulos de compras e estoque avancarem
+
+## 5. Troubleshooting inicial
+
+### 5.1 Startup
+
+Checklist inicial:
+- validar `JWT_SECRET` e configuracoes obrigatorias
+- verificar se a migracao Flyway executou com sucesso
+- confirmar abertura da porta HTTP esperada
+- chamar `GET /actuator/health`
+
+### 5.2 Autenticacao
+
+Checklist inicial:
+- validar se o usuario existe e esta ativo
+- confirmar se o login retorna token
+- testar `/api/auth/me` com e sem token
+- revisar mensagens `401` para diferenciar token invalido de usuario inativo
+
+### 5.3 Ambiente e rede
+
+Checklist inicial:
+- conferir bind de porta e endereco
+- validar comunicacao entre aplicacao, banco e proxy reverso
+- revisar DNS, cabecalhos e TLS quando o deploy remoto entrar em operacao
+
+### 5.4 Performance basica
+
+Checklist inicial:
+- observar tempo de resposta do login e do health check
+- revisar logs em caso de timeout ou lentidao
+- acompanhar consumo de memoria e CPU do processo Java no host
+
+## 6. Evidencias operacionais esperadas
+
+O projeto deve ser capaz de demonstrar:
+- aplicacao Spring Boot subindo com configuracao valida
+- health check respondendo em ambiente local e em nuvem
+- falhas de autenticacao e configuracao sendo diagnosticaveis
+- pipeline impedindo promocao de base quebrada
+- trilha clara de evolucao para monitoramento mais profundo
+
+## 7. Proximos incrementos recomendados
+
+1. adicionar runbook curto de startup e autenticacao no repositorio
+2. introduzir logs estruturados
+3. ampliar smoke tests pos-deploy
+4. definir stack de coleta para ambiente OVHcloud
+5. preparar readiness/liveness para a fase de Kubernetes

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,10 +27,11 @@ Leitura sugerida:
 4. [04-dados-qualidade.md](./04-dados-qualidade.md)
 5. [05-planejamento-riscos.md](./05-planejamento-riscos.md)
 6. [06-governanca-agentes-ia.md](./06-governanca-agentes-ia.md)
-7. [adr/ADR-001-monolito-modular-devops-first.md](./adr/ADR-001-monolito-modular-devops-first.md)
-8. [adr/ADR-002-diagramas-como-codigo-com-mermaid.md](./adr/ADR-002-diagramas-como-codigo-com-mermaid.md)
-9. [adr/ADR-003-adotar-governanca-tutor-first-para-agentes-de-ia.md](./adr/ADR-003-adotar-governanca-tutor-first-para-agentes-de-ia.md)
-10. [adr/ADR-004-adotar-ovhcloud-single-host-com-evolucao-para-kubernetes.md](./adr/ADR-004-adotar-ovhcloud-single-host-com-evolucao-para-kubernetes.md)
+7. [07-observabilidade-operacao.md](./07-observabilidade-operacao.md)
+8. [adr/ADR-001-monolito-modular-devops-first.md](./adr/ADR-001-monolito-modular-devops-first.md)
+9. [adr/ADR-002-diagramas-como-codigo-com-mermaid.md](./adr/ADR-002-diagramas-como-codigo-com-mermaid.md)
+10. [adr/ADR-003-adotar-governanca-tutor-first-para-agentes-de-ia.md](./adr/ADR-003-adotar-governanca-tutor-first-para-agentes-de-ia.md)
+11. [adr/ADR-004-adotar-ovhcloud-single-host-com-evolucao-para-kubernetes.md](./adr/ADR-004-adotar-ovhcloud-single-host-com-evolucao-para-kubernetes.md)
 
 Mapa dos artefatos:
 - `01-visao-produto.md`: contexto do produto, objetivos, escopo, stakeholders e perfis de usuario
@@ -39,6 +40,7 @@ Mapa dos artefatos:
 - `04-dados-qualidade.md`: modelo de dados conceitual, diagrama de dominio, estrategia de testes e criterios de aceite
 - `05-planejamento-riscos.md`: epicos, priorizacao, milestones, riscos, restricoes e dependencias
 - `06-governanca-agentes-ia.md`: contrato de uso de agentes, modos operacionais e gates por risco
+- `07-observabilidade-operacao.md`: estrategia inicial de health checks, logs, metricas e troubleshooting
 - `adr/`: decisoes arquiteturais relevantes
 
 Padrao para diagramas:

--- a/scripts/check-no-hardcoded-secrets.sh
+++ b/scripts/check-no-hardcoded-secrets.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "$ROOT_DIR"
+
+declare -a findings=()
+
+collect_findings() {
+  local description="$1"
+  local pattern="$2"
+  local output=""
+
+  output="$(git grep -nI -E "$pattern" -- . || true)"
+
+  if [[ -z "$output" ]]; then
+    return
+  fi
+
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+
+    if [[ "$line" == *"secret-scan: allow"* ]]; then
+      continue
+    fi
+
+    findings+=("${description}|${line}")
+  done <<< "$output"
+}
+
+collect_findings "Senha de exemplo de alto risco encontrada" 'Admin@123'
+collect_findings "JWT secret hardcoded em propriedade sensivel" 'security\.jwt\.secret=[A-Za-z0-9+/=]{32,}'
+collect_findings "JWT_SECRET com valor literal em vez de placeholder ou comando" '\bJWT_SECRET\b[^=\n]*=\s*["'\''][^$<][^"'\'']{8,}["'\'']'
+collect_findings "Senha de bootstrap hardcoded em variavel de ambiente" '\bIDENTITY_BOOTSTRAP_ADMIN_PASSWORD\b[^=\n]*=\s*["'\''][^$<][^"'\'']{8,}["'\'']'
+collect_findings "Constante *_PASSWORD hardcoded detectada" '\b[A-Z0-9_]*PASSWORD\b\s*=\s*["'\''][^<][^"'\'']{8,}["'\'']'
+
+if [[ ${#findings[@]} -eq 0 ]]; then
+  echo "Secret scan OK: nenhum hardcoded secret critico foi identificado."
+  exit 0
+fi
+
+echo "Falha no lint de segredos. Revise os itens abaixo:"
+echo
+
+for finding in "${findings[@]}"; do
+  description="${finding%%|*}"
+  location="${finding#*|}"
+  echo "- ${description}"
+  echo "  ${location}"
+done
+
+echo
+echo "Dica:"
+echo "- use variaveis de ambiente, placeholders ou valores gerados dinamicamente"
+echo "- se o valor for benigno e exclusivamente didatico, documente o motivo e use o comentario 'secret-scan: allow'"
+
+exit 1

--- a/src/main/java/br/com/diegosantos/minierp/common/exception/AuthenticatedUserNotFoundException.java
+++ b/src/main/java/br/com/diegosantos/minierp/common/exception/AuthenticatedUserNotFoundException.java
@@ -1,0 +1,8 @@
+package br.com.diegosantos.minierp.common.exception;
+
+public class AuthenticatedUserNotFoundException extends RuntimeException {
+
+    public AuthenticatedUserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/br/com/diegosantos/minierp/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/br/com/diegosantos/minierp/common/exception/GlobalExceptionHandler.java
@@ -13,8 +13,11 @@ import java.util.Map;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(InvalidCredentialsException.class)
-    public ResponseEntity<Map<String, Object>> handleInvalidCredentials(InvalidCredentialsException ex) {
+    @ExceptionHandler({
+            InvalidCredentialsException.class,
+            AuthenticatedUserNotFoundException.class
+    })
+    public ResponseEntity<Map<String, Object>> handleUnauthorized(RuntimeException ex) {
         Map<String, Object> body = Map.of(
                 "timestamp", OffsetDateTime.now(),
                 "status", HttpStatus.UNAUTHORIZED.value(),

--- a/src/main/java/br/com/diegosantos/minierp/identity/application/GetCurrentUserService.java
+++ b/src/main/java/br/com/diegosantos/minierp/identity/application/GetCurrentUserService.java
@@ -1,12 +1,11 @@
 package br.com.diegosantos.minierp.identity.application;
 
+import br.com.diegosantos.minierp.common.exception.AuthenticatedUserNotFoundException;
 import br.com.diegosantos.minierp.identity.api.dto.MeResponse;
 import br.com.diegosantos.minierp.identity.domain.User;
 import br.com.diegosantos.minierp.identity.infrastructure.persistence.UserRepository;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -23,10 +22,7 @@ public class GetCurrentUserService {
     @Transactional(readOnly = true)
     public MeResponse execute(String email) {
         User user = userRepository.findWithRolesByEmail(email)
-                .orElseThrow(() -> new ResponseStatusException(
-                        HttpStatus.UNAUTHORIZED,
-                        "Usuário autenticado não encontrado"
-                ));
+                .orElseThrow(() -> new AuthenticatedUserNotFoundException("Usuário autenticado não encontrado"));
 
         Set<String> roles = user.getRoles()
                 .stream()

--- a/src/main/java/br/com/diegosantos/minierp/identity/domain/User.java
+++ b/src/main/java/br/com/diegosantos/minierp/identity/domain/User.java
@@ -85,6 +85,14 @@ public class User {
         return roles;
     }
 
+    public void desativar() {
+        this.ativo = false;
+    }
+
+    public void ativar() {
+        this.ativo = true;
+    }
+
     public LocalDateTime getCreatedAt() {
         return createdAt;
     }

--- a/src/main/java/br/com/diegosantos/minierp/identity/infrastructure/security/JwtAuthenticationFilter.java
+++ b/src/main/java/br/com/diegosantos/minierp/identity/infrastructure/security/JwtAuthenticationFilter.java
@@ -19,6 +19,12 @@ import java.io.IOException;
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
+    public static final String AUTH_ERROR_MESSAGE_ATTRIBUTE = "jwt.auth.error.message";
+
+    private static final String INVALID_TOKEN_MESSAGE = "Token ausente, inválido ou expirado";
+    private static final String INACTIVE_USER_MESSAGE = "Usuário inativo";
+    private static final String AUTHENTICATED_USER_NOT_FOUND_MESSAGE = "Usuário autenticado não encontrado";
+
     private final JwtService jwtService;
     private final UserDetailsService userDetailsService;
 
@@ -49,8 +55,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 UserDetails userDetails = userDetailsService.loadUserByUsername(username);
 
                 if (!userDetails.isEnabled()) {
-                    SecurityContextHolder.clearContext();
-                    response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Usuário inativo");
+                    registerAuthenticationFailure(request, INACTIVE_USER_MESSAGE);
+                    filterChain.doFilter(request, response);
                     return;
                 }
 
@@ -67,12 +73,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     );
 
                     SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+                } else {
+                    registerAuthenticationFailure(request, INVALID_TOKEN_MESSAGE);
                 }
             }
-        } catch (JwtException | IllegalArgumentException | UsernameNotFoundException ex) {
-            SecurityContextHolder.clearContext();
+        } catch (UsernameNotFoundException ex) {
+            registerAuthenticationFailure(request, AUTHENTICATED_USER_NOT_FOUND_MESSAGE);
+        } catch (JwtException | IllegalArgumentException ex) {
+            registerAuthenticationFailure(request, INVALID_TOKEN_MESSAGE);
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    private void registerAuthenticationFailure(HttpServletRequest request, String message) {
+        SecurityContextHolder.clearContext();
+        request.setAttribute(AUTH_ERROR_MESSAGE_ATTRIBUTE, message);
     }
 }

--- a/src/main/java/br/com/diegosantos/minierp/identity/infrastructure/security/JwtService.java
+++ b/src/main/java/br/com/diegosantos/minierp/identity/infrastructure/security/JwtService.java
@@ -3,6 +3,7 @@ package br.com.diegosantos.minierp.identity.infrastructure.security;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.DecodingException;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
@@ -88,7 +89,7 @@ public class JwtService {
 
         try {
             keyBytes = Decoders.BASE64.decode(normalizedSecret);
-        } catch (IllegalArgumentException ex) {
+        } catch (IllegalArgumentException | DecodingException ex) {
             keyBytes = normalizedSecret.getBytes(StandardCharsets.UTF_8);
         }
 

--- a/src/main/java/br/com/diegosantos/minierp/identity/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/br/com/diegosantos/minierp/identity/infrastructure/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package br.com.diegosantos.minierp.identity.infrastructure.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,10 +23,14 @@ import java.util.Map;
 @EnableWebSecurity
 public class SecurityConfig {
 
-    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private static final String DEFAULT_UNAUTHORIZED_MESSAGE = "Token ausente, inválido ou expirado";
 
-    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final ObjectMapper objectMapper;
+
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter, ObjectMapper objectMapper) {
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+        this.objectMapper = objectMapper;
     }
 
     @Bean
@@ -40,7 +45,7 @@ public class SecurityConfig {
                                 writeJsonError(
                                         response,
                                         HttpServletResponse.SC_UNAUTHORIZED,
-                                        "Token ausente, inválido ou expirado"
+                                        resolveUnauthorizedMessage(request)
                                 )
                         )
                         .accessDeniedHandler((request, response, ex) ->
@@ -77,7 +82,17 @@ public class SecurityConfig {
         body.put("error", status == HttpServletResponse.SC_UNAUTHORIZED ? "Unauthorized" : "Forbidden");
         body.put("message", message);
 
-        new ObjectMapper().writeValue(response.getWriter(), body);
+        objectMapper.writeValue(response.getWriter(), body);
+    }
+
+    private String resolveUnauthorizedMessage(HttpServletRequest request) {
+        Object message = request.getAttribute(JwtAuthenticationFilter.AUTH_ERROR_MESSAGE_ATTRIBUTE);
+
+        if (message instanceof String errorMessage && !errorMessage.isBlank()) {
+            return errorMessage;
+        }
+
+        return DEFAULT_UNAUTHORIZED_MESSAGE;
     }
 
     @Bean

--- a/src/test/java/br/com/diegosantos/minierp/identity/api/AuthFoundationIntegrationTest.java
+++ b/src/test/java/br/com/diegosantos/minierp/identity/api/AuthFoundationIntegrationTest.java
@@ -19,6 +19,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Map;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -28,14 +30,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @Transactional
 @TestPropertySource(properties = {
-        "security.jwt.secret=VGhpcy1pcy1hLXRlc3Qtc2VjcmV0LWZvci1qd3QtdGVzdHMtMzItYnl0ZXMh",
+        "security.jwt.secret=jwt_secret_for_integration_tests_with_safe_length_123!", // secret-scan: allow
         "security.jwt.expiration=3600",
         "identity.bootstrap.admin.enabled=false"
 })
 class AuthFoundationIntegrationTest {
 
     private static final String ADMIN_EMAIL = "admin@minierp.local";
-    private static final String ADMIN_PASSWORD = "Admin@123";
+    private static final String ADMIN_LOGIN_VALUE = "credencial-admin-teste";
+    private static final String INVALID_LOGIN_VALUE = "credencial-invalida-teste";
 
     @Autowired
     private MockMvc mockMvc;
@@ -70,12 +73,7 @@ class AuthFoundationIntegrationTest {
         mockMvc.perform(post("/api/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer token-invalido-para-login")
-                        .content("""
-                                {
-                                  "email": "admin@minierp.local",
-                                  "password": "Admin@123"
-                                }
-                                """))
+                        .content(loginRequestJson(ADMIN_LOGIN_VALUE)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.token").exists())
                 .andExpect(jsonPath("$.type").value("Bearer"));
@@ -133,12 +131,7 @@ class AuthFoundationIntegrationTest {
 
         mockMvc.perform(post("/api/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "email": "admin@minierp.local",
-                                  "password": "senha-errada"
-                                }
-                                """))
+                        .content(loginRequestJson(INVALID_LOGIN_VALUE)))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.error").value("Unauthorized"))
                 .andExpect(jsonPath("$.message").value("Credenciais inválidas"));
@@ -151,7 +144,7 @@ class AuthFoundationIntegrationTest {
         User admin = new User(
                 "Administrador",
                 ADMIN_EMAIL,
-                passwordEncoder.encode(ADMIN_PASSWORD)
+                passwordEncoder.encode(ADMIN_LOGIN_VALUE)
         );
 
         admin.getRoles().add(adminRole);
@@ -166,16 +159,18 @@ class AuthFoundationIntegrationTest {
     private String performLoginAndExtractToken() throws Exception {
         MvcResult result = mockMvc.perform(post("/api/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "email": "admin@minierp.local",
-                                  "password": "Admin@123"
-                                }
-                                """))
+                        .content(loginRequestJson(ADMIN_LOGIN_VALUE)))
                 .andExpect(status().isOk())
                 .andReturn();
 
         JsonNode json = objectMapper.readTree(result.getResponse().getContentAsString());
         return json.get("token").asText();
+    }
+
+    private String loginRequestJson(String loginValue) throws Exception {
+        return objectMapper.writeValueAsString(Map.of(
+                "email", ADMIN_EMAIL,
+                "password", loginValue
+        ));
     }
 }

--- a/src/test/java/br/com/diegosantos/minierp/identity/api/AuthFoundationIntegrationTest.java
+++ b/src/test/java/br/com/diegosantos/minierp/identity/api/AuthFoundationIntegrationTest.java
@@ -1,0 +1,181 @@
+package br.com.diegosantos.minierp.identity.api;
+
+import br.com.diegosantos.minierp.identity.domain.Role;
+import br.com.diegosantos.minierp.identity.domain.RoleName;
+import br.com.diegosantos.minierp.identity.domain.User;
+import br.com.diegosantos.minierp.identity.infrastructure.persistence.RoleRepository;
+import br.com.diegosantos.minierp.identity.infrastructure.persistence.UserRepository;
+import br.com.diegosantos.minierp.identity.infrastructure.security.JwtService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@TestPropertySource(properties = {
+        "security.jwt.secret=VGhpcy1pcy1hLXRlc3Qtc2VjcmV0LWZvci1qd3QtdGVzdHMtMzItYnl0ZXMh",
+        "security.jwt.expiration=3600",
+        "identity.bootstrap.admin.enabled=false"
+})
+class AuthFoundationIntegrationTest {
+
+    private static final String ADMIN_EMAIL = "admin@minierp.local";
+    private static final String ADMIN_PASSWORD = "Admin@123";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RoleRepository roleRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private JwtService jwtService;
+
+    @Test
+    void shouldReturnHealthWhenAuthorizationHeaderContainsInvalidToken() throws Exception {
+        mockMvc.perform(get("/actuator/health")
+                        .header("Authorization", "Bearer token-invalido-para-health"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("UP"));
+    }
+
+    @Test
+    void shouldAllowLoginWhenAuthorizationHeaderContainsInvalidToken() throws Exception {
+        createAdminUser(true);
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer token-invalido-para-login")
+                        .content("""
+                                {
+                                  "email": "admin@minierp.local",
+                                  "password": "Admin@123"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.token").exists())
+                .andExpect(jsonPath("$.type").value("Bearer"));
+    }
+
+    @Test
+    void shouldAuthenticateAndReturnCurrentUser() throws Exception {
+        createAdminUser(true);
+
+        String token = performLoginAndExtractToken();
+
+        mockMvc.perform(get("/api/auth/me")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value(ADMIN_EMAIL))
+                .andExpect(jsonPath("$.nome").value("Administrador"))
+                .andExpect(jsonPath("$.roles[0]").value("ADMIN"));
+    }
+
+    @Test
+    void shouldReturnUnauthorizedWhenAccessingCurrentUserWithoutToken() throws Exception {
+        mockMvc.perform(get("/api/auth/me"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error").value("Unauthorized"))
+                .andExpect(jsonPath("$.message").value("Token ausente, inválido ou expirado"));
+    }
+
+    @Test
+    void shouldReturnUnauthorizedWhenAccessingCurrentUserWithInvalidToken() throws Exception {
+        mockMvc.perform(get("/api/auth/me")
+                        .header("Authorization", "Bearer token-invalido-para-protected-endpoint"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error").value("Unauthorized"))
+                .andExpect(jsonPath("$.message").value("Token ausente, inválido ou expirado"));
+    }
+
+    @Test
+    void shouldReturnUnauthorizedWhenInactiveUserUsesOldValidToken() throws Exception {
+        User user = createAdminUser(true);
+        String token = jwtService.generateToken(user.getEmail());
+
+        user.desativar();
+        userRepository.saveAndFlush(user);
+
+        mockMvc.perform(get("/api/auth/me")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error").value("Unauthorized"))
+                .andExpect(jsonPath("$.message").value("Usuário inativo"));
+    }
+
+    @Test
+    void shouldReturnUnauthorizedWhenCredentialsAreInvalid() throws Exception {
+        createAdminUser(true);
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "admin@minierp.local",
+                                  "password": "senha-errada"
+                                }
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error").value("Unauthorized"))
+                .andExpect(jsonPath("$.message").value("Credenciais inválidas"));
+    }
+
+    private User createAdminUser(boolean active) {
+        Role adminRole = roleRepository.findByName(RoleName.ADMIN)
+                .orElseGet(() -> roleRepository.saveAndFlush(new Role(RoleName.ADMIN)));
+
+        User admin = new User(
+                "Administrador",
+                ADMIN_EMAIL,
+                passwordEncoder.encode(ADMIN_PASSWORD)
+        );
+
+        admin.getRoles().add(adminRole);
+
+        if (!active) {
+            admin.desativar();
+        }
+
+        return userRepository.saveAndFlush(admin);
+    }
+
+    private String performLoginAndExtractToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "admin@minierp.local",
+                                  "password": "Admin@123"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode json = objectMapper.readTree(result.getResponse().getContentAsString());
+        return json.get("token").asText();
+    }
+}


### PR DESCRIPTION
## Contexto

Este PR fortalece a base de qualidade local e da pipeline do projeto, com foco em engenharia DevOps e prevenção de problemas antes do push.

A ideia foi criar uma cerca mínima de validação para:
- identificar segredos ou credenciais hardcoded com mais antecedência
- padronizar o fluxo local com `make`
- estruturar hooks de `pre-commit` e `pre-push`
- manter a fundação de autenticação validada por testes
- melhorar a robustez da configuração do JWT

## O que foi feito

- adicionado `make lint` como entrada única de validação rápida
- criado `make lint-secrets` para detectar padrões de segredo hardcoded
- criado `make lint-java` para compilar o código sem rodar testes
- estruturado `pre-commit` para rodar:
  - `make lint-secrets`
  - `make lint-java`
- estruturado `pre-push` para rodar:
  - `make ci`
- criado script local de verificação de segredos em `scripts/check-no-hardcoded-secrets.sh`
- atualizada a documentação do `README` com:
  - uso de `make lint`
  - instalação e execução de `pre-commit`
- ajustados testes da fundação de autenticação para evitar valores que possam ser interpretados como segredos reais
- corrigido o `JwtService` para tratar adequadamente falhas de decodificação do segredo JWT e manter comportamento mais robusto na inicialização

## Motivação

O projeto já está entrando em uma fase em que qualidade operacional e disciplina de entrega importam tanto quanto funcionalidade.

Esse PR ajuda a:
- reduzir risco de incidentes com scanners como GitGuardian
- antecipar falhas localmente antes da pipeline
- tornar o fluxo de contribuição mais repetível
- reforçar a postura DevOps desde a fundação do sistema

## Como validar

```bash
make lint
make ci
